### PR TITLE
给cos_err增加一个status_code

### DIFF
--- a/qcloud_cos/cos_err.py
+++ b/qcloud_cos/cos_err.py
@@ -10,5 +10,5 @@ class CosErr(object):
     UNKNOWN_ERROR = -4  # 未知错误
 
     @staticmethod
-    def get_err_msg(errcode, err_info):
-        return {u'code': errcode, u'message': err_info}
+    def get_err_msg(errcode, err_info, status_code = None):
+        return {u'code': errcode, u'message': err_info, u'status_code': status_code}

--- a/qcloud_cos/cos_op.py
+++ b/qcloud_cos/cos_op.py
@@ -108,7 +108,7 @@ class BaseOp(object):
             else:
                 logger.warning("request failed, response message: %s" % http_resp.text)
                 err_detail = 'url:%s, status_code:%d' % (url, status_code)
-                return CosErr.get_err_msg(CosErr.NETWORK_ERROR, err_detail)
+                return CosErr.get_err_msg(CosErr.NETWORK_ERROR, err_detail, status_code)
         except Exception as e:
             logger.exception("request failed, return SERVER_ERROR")
             err_detail = 'url:%s, exception:%s traceback:%s' % (url, str(e), format_exc())


### PR DESCRIPTION
cos_err的code只有-1、-2、-3、-4，不能反映具体的错误原因，根据api文档，应当使用status_code判断错误原因。